### PR TITLE
Minor improvements to plugin.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-var fs          = require('fs');
-var path        = require('path');
 var sass        = require('node-sass');
 var cacheHelper = require('documark-cache');
 
@@ -9,21 +7,20 @@ module.exports = function dmpSass ($, document, done) {
     outputStyle: 'compressed',
     sourceMap: false,
     success: function (result) {
-      var cache = cacheHelper(document);
-      var file = cache.fileWriteStream('sass-cache.css');
-      var container = $('head');
+      var file       = cacheHelper(document).fileWriteStream('dmp-sass.css');
+      var $container = $('head');
 
-      if ( !container.length ) {
-        container = $.root();
+      if ( ! $container.length) {
+        $container = $.root();
       }
 
       file.end(result.css);
-      container.append('<link rel="stylesheet" type="text/css" href="' + cache.filePath('sass-cache.css') + '">');
+      $container.append('<link rel="stylesheet" type="text/css" href="file://' + file.path + '"/>');
 
       done();
     },
-    error: function (error) {
-      done(error.message);
+    error: function (err) {
+      done(err.message);
     }
   });
 };


### PR DESCRIPTION
Remove unused modules: fs and path.
Do not store cacheHelper instance, we now only need it once.
Rename cache file to 'dmp-sass.css' to indicate that it came from this plugin.
Prefix container with $ (best practice from DOM instances).
Prefix link href with 'file://', for older versions of wkhtmltopdf.
Use file stream path instead of cache.filePath(...).

Sorry, I was tired of writing documents so I figured: why not help a brotha out?
